### PR TITLE
Fix bug that missed handleURL

### DIFF
--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -484,6 +484,7 @@ open class MessageLabel: UILabel {
                 validSchemes.append(bundleName.lowercased())
             }
             guard let url = url, let scheme = url.scheme?.lowercased(), validSchemes.contains(scheme) else { return }
+            handleURL(url)
         case let .transitInfoComponents(transitInformation):
             var transformedTransitInformation = [String: String]()
             guard let transitInformation = transitInformation else { return }


### PR DESCRIPTION
`handleURL(url)` was removed with misstake in previous PR (https://github.com/quipper/MessageKit/pull/14 )🙇‍♂️🙇‍♂️
So I will restore the code🙇‍♂️

![image](https://user-images.githubusercontent.com/19669205/115008633-4f000480-9ee6-11eb-80ff-e89f964e70c4.png)
