### PR TITLE
Override showCGGlyphs for foregroundColor

### DIFF
--- a/MessageKit.xcodeproj/project.pbxproj
+++ b/MessageKit.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		B7A03F731F866A06006AEF79 /* MessageKit+Availability.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7A03F701F866A06006AEF79 /* MessageKit+Availability.swift */; };
 		B7A03F751F866A06006AEF79 /* MessageKit.h in Headers */ = {isa = PBXBuildFile; fileRef = B7A03F721F866A06006AEF79 /* MessageKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B7A03F7B1F866B85006AEF79 /* MessageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7A03F7A1F866B85006AEF79 /* MessageCollectionViewCell.swift */; };
+		E1123DFB26818D1D00DE7AD8 /* MessageLayoutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1123DFA26818D1D00DE7AD8 /* MessageLayoutManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -214,6 +215,7 @@
 		B7A03F711F866A06006AEF79 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B7A03F721F866A06006AEF79 /* MessageKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MessageKit.h; sourceTree = "<group>"; };
 		B7A03F7A1F866B85006AEF79 /* MessageCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageCollectionViewCell.swift; sourceTree = "<group>"; };
+		E1123DFA26818D1D00DE7AD8 /* MessageLayoutManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageLayoutManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -450,6 +452,7 @@
 				1FE783A7206633C0007FA024 /* InsetLabel.swift */,
 				B7A03F431F86694F006AEF79 /* MessageContainerView.swift */,
 				B7A03F3F1F86694F006AEF79 /* MessageLabel.swift */,
+				E1123DFA26818D1D00DE7AD8 /* MessageLayoutManager.swift */,
 				B7A03F451F86694F006AEF79 /* MessagesCollectionView.swift */,
 				B7A03F441F86694F006AEF79 /* PlayButtonView.swift */,
 				38F8063421740DAD00CDB9DB /* TypingBubble.swift */,
@@ -670,6 +673,7 @@
 				B7A03F6D1F8669EB006AEF79 /* Bundle+Extensions.swift in Sources */,
 				1FD589602064E08A004B5081 /* MediaItem.swift in Sources */,
 				B7A03F611F8669CA006AEF79 /* MessagesDataSource.swift in Sources */,
+				E1123DFB26818D1D00DE7AD8 /* MessageLayoutManager.swift in Sources */,
 				5955CE4C23140AA1000987D0 /* AudioMessageCell.swift in Sources */,
 				B7A03F6E1F8669EB006AEF79 /* NSAttributedString+Extensions.swift in Sources */,
 				B7A03F471F86694F006AEF79 /* MessageLabel.swift in Sources */,

--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -28,8 +28,8 @@ open class MessageLabel: UILabel {
 
     // MARK: - Private Properties
 
-    private lazy var layoutManager: NSLayoutManager = {
-        let layoutManager = NSLayoutManager()
+    private lazy var layoutManager: MessageLayoutManager = {
+        let layoutManager = MessageLayoutManager()
         layoutManager.addTextContainer(self.textContainer)
         return layoutManager
     }()
@@ -540,4 +540,23 @@ internal enum MessageTextCheckingType {
     case link(URL?)
     case transitInfoComponents([NSTextCheckingKey: String]?)
     case custom(pattern: String, match: String?)
+}
+
+
+private class MessageLayoutManager: NSLayoutManager {
+    @available(iOS 13.0, *)
+    override func showCGGlyphs(_ glyphs: UnsafePointer<CGGlyph>,
+                               positions: UnsafePointer<CGPoint>,
+                                   count glyphCount: Int,
+                                    font: UIFont,
+                              textMatrix: CGAffineTransform,
+                              attributes: [NSAttributedString.Key : Any] = [:],
+                              in CGContext: CGContext) {
+
+        if let foregroundColor = attributes[NSAttributedString.Key.foregroundColor] as? UIColor {
+            CGContext.setFillColor(foregroundColor.cgColor)
+        }
+
+        super.showCGGlyphs(glyphs, positions: positions, count: glyphCount, font: font, textMatrix: textMatrix, attributes: attributes, in: CGContext)
+    }
 }

--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -541,22 +541,3 @@ internal enum MessageTextCheckingType {
     case transitInfoComponents([NSTextCheckingKey: String]?)
     case custom(pattern: String, match: String?)
 }
-
-
-private class MessageLayoutManager: NSLayoutManager {
-    @available(iOS 13.0, *)
-    override func showCGGlyphs(_ glyphs: UnsafePointer<CGGlyph>,
-                               positions: UnsafePointer<CGPoint>,
-                                   count glyphCount: Int,
-                                    font: UIFont,
-                              textMatrix: CGAffineTransform,
-                              attributes: [NSAttributedString.Key : Any] = [:],
-                              in CGContext: CGContext) {
-
-        if let foregroundColor = attributes[NSAttributedString.Key.foregroundColor] as? UIColor {
-            CGContext.setFillColor(foregroundColor.cgColor)
-        }
-
-        super.showCGGlyphs(glyphs, positions: positions, count: glyphCount, font: font, textMatrix: textMatrix, attributes: attributes, in: CGContext)
-    }
-}

--- a/Sources/Views/MessageLayoutManager.swift
+++ b/Sources/Views/MessageLayoutManager.swift
@@ -1,0 +1,27 @@
+//
+//  MessageLayoutManager.swift
+//  MessageKit
+//
+//  Created by Bokyung Kwon on 2021/06/22.
+//  Copyright © 2021 MessageKit. All rights reserved.
+//
+
+import UIKit
+
+open class MessageLayoutManager: NSLayoutManager {
+    @available(iOS 13.0, *)
+    override func showCGGlyphs(_ glyphs: UnsafePointer<CGGlyph>,
+                               positions: UnsafePointer<CGPoint>,
+                                   count glyphCount: Int,
+                                    font: UIFont,
+                              textMatrix: CGAffineTransform,
+                              attributes: [NSAttributedString.Key : Any] = [:],
+                              in CGContext: CGContext) {
+
+        if let foregroundColor = attributes[NSAttributedString.Key.foregroundColor] as? UIColor {
+            CGContext.setFillColor(foregroundColor.cgColor)
+        }
+
+        super.showCGGlyphs(glyphs, positions: positions, count: glyphCount, font: font, textMatrix: textMatrix, attributes: attributes, in: CGContext)
+    }
+}


### PR DESCRIPTION
### 問題
- HTMLのメッセージデーターをattributedStringに表示する際にhyperlinkの色を変更しても反映されずに青色になる

### 原因
> NSLayoutManager has a internal color hard-coded for glyph ranges belonging to a hyperlink. 
- 参考にしたURL：https://www.cocoanetics.com/2015/03/customizing-uilabel-hyperlinks

### 修正
- MessageLabelでNSLayoutManagerではなくMessageLayoutManagerを新規で作り
foregroundColorが有れば必ずsetfillするようにする

before | after
:--:|:--:
![image](https://user-images.githubusercontent.com/19669205/122850698-abe5c400-d348-11eb-9b71-26289aae70a9.png)|![image](https://user-images.githubusercontent.com/19669205/122850745-bd2ed080-d348-11eb-8721-d0784ed0f502.png)

### 懸念点
- https://developer.apple.com/documentation/uikit/nslayoutmanager/3180379-showcgglyphs
- iOS13以上の制限があるが、ウチのアプリはiOS13から支援するので特に問題ないはず
