### PR TITLE
Add open keyword to fix build fail

### DIFF
--- a/Sources/Views/MessageLayoutManager.swift
+++ b/Sources/Views/MessageLayoutManager.swift
@@ -10,7 +10,7 @@ import UIKit
 
 open class MessageLayoutManager: NSLayoutManager {
     @available(iOS 13.0, *)
-    override func showCGGlyphs(_ glyphs: UnsafePointer<CGGlyph>,
+    open override func showCGGlyphs(_ glyphs: UnsafePointer<CGGlyph>,
                                positions: UnsafePointer<CGPoint>,
                                    count glyphCount: Int,
                                     font: UIFont,


### PR DESCRIPTION
- `open`が抜けていてビルド失敗になってたことを後から気づきました🙇‍♂️🙇‍♂️🙇‍♂️