### PR TITLE
Set lineFragmentPadding as 0

### DIFF
--- a/Sources/Layout/MessageSizeCalculator.swift
+++ b/Sources/Layout/MessageSizeCalculator.swift
@@ -325,6 +325,7 @@ open class MessageSizeCalculator: CellSizeCalculator {
         let boundingRect = CGRect(origin: .zero, size: containerSize)
         let textStorage = NSTextStorage(attributedString: attributedText)
         let textContainer = NSTextContainer(size: containerSize)
+        textContainer.lineFragmentPadding = 0
 
         let layoutManager = NSLayoutManager()
         layoutManager.addTextContainer(textContainer)


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/19669205/124048205-c27ad200-da50-11eb-956a-2149acbcbbc6.png)

- lineFragmentPadding's default value is 5
- To calculating correct message size, it needed to change as 0

- Ref : https://github.com/quipper/qlearn-aya-ios/pull/3154 