### PR TITLE
Fix type of annoucement

### DIFF
--- a/Example/Sources/View Controllers/AnnouncementExampleViewController.swift
+++ b/Example/Sources/View Controllers/AnnouncementExampleViewController.swift
@@ -112,7 +112,7 @@ class AnnouncementExampleViewController: MessagesViewController {
 
         let kind: MessageKind
         if message.isAnnouncement || message.isWarning {
-            kind = .announcement(message.text ?? "")
+            kind = .announcement(NSAttributedString(string: message.text ?? ""))
         } else if isImageMessage(message) {
             let media = mediaItem(from: message)
             kind = .photo(media)


### PR DESCRIPTION
## Overview

I fixed a compilation error in AnnouncementExampleViewController.swift.

## Problem

`Cannot convert value of type 'String' to expected argument type 'NSAttributedString'` at https://github.com/quipper/MessageKit/blob/d864bed158451b1ba7023d77c2ce63f980f74ed8/Example/Sources/View%20Controllers/AnnouncementExampleViewController.swift#L115

`.annoucement` is defined at https://github.com/quipper/MessageKit/blob/d864bed158451b1ba7023d77c2ce63f980f74ed8/Sources/Models/MessageKind.swift#L61

Its type has been changed at this commit https://github.com/quipper/MessageKit/commit/a474e3ecbb1b38ff0a01141a3fcdf81b9fb33a6f

## Screenshot

<img width="491" alt="image" src="https://github.com/quipper/MessageKit/assets/1672393/447570d0-8a9d-40e3-9bda-85ef383b8893">
